### PR TITLE
Enable using the option to build position independent code.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -44,6 +44,8 @@ class LibtiffConan(ConanFile):
         cmake.definitions['CMAKE_INSTALL_BINDIR'] = 'bin'
         cmake.definitions['CMAKE_INSTALL_INCLUDEDIR'] = 'include'
 
+        cmake.definitions['CMAKE_POSITION_INDEPENDENT_CODE'] = self.options.fPIC
+
         cmake.definitions["lzma"] = False
         cmake.definitions["jpeg"] = False
         cmake.definitions["jbig"] = False


### PR DESCRIPTION
If a user turns on fPIC, nothing happened because CMake wasn't told about it.  Correct by setting CMAKE_POSITION_INDEPENDENT_CODE in cmake definitions.