### PR TITLE
Fix build failure in mingw64

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -54,11 +54,15 @@ class LibtiffConan(ConanFile):
                                   r'set_target_properties(tiffxx PROPERTIES SOVERSION ${SO_COMPATVERSION} '
                                   r'WINDOWS_EXPORT_ALL_SYMBOLS ON)')
 
-        if self.settings.os == "Windows" and self.settings.compiler != "Visual Studio" and self.version == '4.0.8':
-            # only one occurence must be patched. fixed in 4.0.9
+        if self.settings.os == "Windows" and self.settings.compiler != "Visual Studio":
             tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeListsOriginal.txt"),
-                                  "if (UNIX)",
-                                  "if (UNIX OR MINGW)")
+                                      "find_library(M_LIBRARY m)",
+                                      "if (NOT MINGW)\n  find_library(M_LIBRARY m)\nendif()")
+            if self.version == '4.0.8':
+                # only one occurence must be patched. fixed in 4.0.9
+                tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeListsOriginal.txt"),
+                                      "if (UNIX)",
+                                      "if (UNIX OR MINGW)")
 
         cmake.definitions["BUILD_SHARED_LIBS"] = self.options.shared
         cmake.configure(source_folder=self._source_subfolder)


### PR DESCRIPTION
In mingw64, linking libm may cause multiple definition because of conflicting with libmsvcrt, this patch fixed the problem